### PR TITLE
Do simple timings

### DIFF
--- a/pfb/test/test_wavelets.py
+++ b/pfb/test/test_wavelets.py
@@ -242,8 +242,13 @@ def test_wavedecn_waverecn(data_shape):
     rec = waverecn(a, coeffs, "db1", "symmetric")
     assert_array_almost_equal(pywt_rec, rec)
 
+    import time
+    start = time.clock()
     out = pywt.wavedecn(data, "db1", "symmetric", axes=(1, 2))
+    pwavedecnt = time.clock() - start
+    start = time.clock()
     a, coeffs = wavedecn(data, "db1", "symmetric", axis=(1, 2))
+    wavedecnt = time.clock() - start
 
     assert_array_almost_equal(a, out[0])
 
@@ -253,9 +258,22 @@ def test_wavedecn_waverecn(data_shape):
         for k, v in d1.items():
             assert_array_almost_equal(v, d2[k])
 
+    start = time.clock()
     pywt_rec = pywt.waverecn(out, "db1", "symmetric", axes=(1, 2))
+    pwaverecnt = time.clock() - start
+
+    start = time.clock()
     rec = waverecn(a, coeffs, "db1", "symmetric", axis=(1, 2))
+    waverecnt = time.clock() - start
     assert_array_almost_equal(pywt_rec, rec)
+
+    print("pywt.wavedecn", pwavedecnt)
+    print("wavedecn", wavedecnt)
+    print("Decomposition ratio", wavedecnt / pwavedecnt)
+    print("pywt.waverecn", pwaverecnt)
+    print("waverecn", waverecnt)
+    print("Reconstruction ratio", waverecnt / pwaverecnt)
+
 
 
     out = pywt.wavedecn(data, "db1", "symmetric", level=2, axes=(1, 2))


### PR DESCRIPTION
I did some simple timings with waverecn and wavedecn. Unforunately the numba versions seem much slower!

```bash
$ py.test -s -vvv pfb/test/test_wavelets.py  -k test_wavedecn
===================================================================================== test session starts =====================================================================================
platform linux -- Python 3.6.9, pytest-5.4.1, py-1.8.1, pluggy-0.13.1 -- /home/sperkins/venv/pfb/bin/python3
cachedir: .pytest_cache
rootdir: /home/sperkins/work/ska/code/pfb-clean
collected 38 items / 37 deselected / 1 selected                                                                                                                                               

pfb/test/test_wavelets.py::test_wavedecn_waverecn[data_shape0] pywt.wavedecn 0.0014719999999996958
wavedecn 0.03976500000000005
Decomposition ratio 27.014266304353445
pywt.waverecn 0.0015099999999996783
waverecn 0.04334099999999985
Reconstruction ratio 28.702649006628533
PASSED
```